### PR TITLE
- Fixed mouse buttons very rarely blocking keyboard keys (with mouse …

### DIFF
--- a/src/App/Osu/Osu.cpp
+++ b/src/App/Osu/Osu.cpp
@@ -1186,6 +1186,10 @@ void Osu::onKey1Change(bool pressed, bool mouse)
 	{
 		if (!(mouse && osu_disable_mousebuttons.getBool()))
 		{
+			// quickfix
+			if (osu_disable_mousebuttons.getBool())
+				m_bMouseKey1Down = false;
+
 			if (pressed && !(m_bKeyboardKey1Down && m_bMouseKey1Down))
 				getSelectedBeatmap()->keyPressed1();
 			else if (!m_bKeyboardKey1Down && !m_bMouseKey1Down)
@@ -1210,6 +1214,10 @@ void Osu::onKey2Change(bool pressed, bool mouse)
 	{
 		if (!(mouse && osu_disable_mousebuttons.getBool()))
 		{
+			// quickfix
+			if (osu_disable_mousebuttons.getBool())
+				m_bMouseKey2Down = false;
+
 			if (pressed && !(m_bKeyboardKey2Down && m_bMouseKey2Down))
 				getSelectedBeatmap()->keyPressed2();
 			else if (!m_bKeyboardKey2Down && !m_bMouseKey2Down)

--- a/src/App/Osu/OsuOptionsMenu.cpp
+++ b/src/App/Osu/OsuOptionsMenu.cpp
@@ -329,6 +329,7 @@ OsuOptionsMenu::OsuOptionsMenu(Osu *osu) : OsuScreenBackable(osu)
 	m_playfieldBorderSizeSlider->setChangeCallback( fastdelegate::MakeDelegate(this, &OsuOptionsMenu::onSliderChangeInt) );
 
 	addSubSection("Hitobjects");
+	addCheckbox("Shrinking Sliders", convar->getConVarByName("osu_slider_shrink"));
 	addCheckbox("Use New Hidden Fading Sliders", convar->getConVarByName("osu_mod_hd_slider_fade"));
 	addCheckbox("Use Fast Hidden Fading Sliders (!)", convar->getConVarByName("osu_mod_hd_slider_fast_fade"));
 	addCheckbox("Use Score V2 slider accuracy", convar->getConVarByName("osu_slider_scorev2"));
@@ -342,7 +343,6 @@ OsuOptionsMenu::OsuOptionsMenu(Osu *osu) : OsuScreenBackable(osu)
 	addCheckbox("Rainbow Sliders", convar->getConVarByName("osu_slider_rainbow"));
 	addCheckbox("Rainbow Numbers", convar->getConVarByName("osu_circle_number_rainbow"));
 	addCheckbox("SliderBreak Epilepsy", convar->getConVarByName("osu_slider_break_epilepsy"));
-	addCheckbox("Shrinking Sliders", convar->getConVarByName("osu_slider_shrink"));
 	addCheckbox("Invisible Cursor", convar->getConVarByName("osu_hide_cursor_during_gameplay"));
 
 


### PR DESCRIPTION
…buttons disabled), getting m_bMouseKey1Down/m_bMouseKey2Down stuck

- Moved "Shrinking Sliders" option from "Bullshit" to "Hitobjects" (Options > Gameplay > Hitobjects)