### PR TITLE
Add laser drawing options and headset brightness slider

### DIFF
--- a/src/App/Osu/OsuOptionsMenu.cpp
+++ b/src/App/Osu/OsuOptionsMenu.cpp
@@ -606,6 +606,7 @@ OsuOptionsMenu::OsuOptionsMenu(Osu *osu) : OsuScreenBackable(osu)
 		addSlider("RenderModel Brightness", 0.1f, 10.0f, convar->getConVarByName("vr_controller_model_brightness_multiplier"))->setKeyDelta(0.1f);
 		addSlider("Background Brightness", 0.0f, 1.0f, convar->getConVarByName("vr_background_brightness"))->setKeyDelta(0.05f);
 		addSlider("VR Cursor Opacity", 0.0f, 1.0f, convar->getConVarByName("osu_vr_cursor_alpha"))->setKeyDelta(0.1f);
+		addSlider("Head RenderModel Brightness", 0.0f, 1.5f, convar->getConVarByName("vr_head_rendermodel_brightness"))->setKeyDelta(0.01f);
 		addSpacer();
 		m_vrApproachDistanceSlider = addSlider("Approach Distance", 0.0f, 50.0f, convar->getConVarByName("osu_vr_approach_distance"), 175.0f);
 		m_vrApproachDistanceSlider->setChangeCallback( fastdelegate::MakeDelegate(this, &OsuOptionsMenu::onSliderChangeOneDecimalPlaceMeters) );

--- a/src/App/Osu/OsuOptionsMenu.cpp
+++ b/src/App/Osu/OsuOptionsMenu.cpp
@@ -641,7 +641,8 @@ OsuOptionsMenu::OsuOptionsMenu(Osu *osu) : OsuScreenBackable(osu)
 		addSpacer();
 		addCheckbox("Draw HMD to Window (!)", "If this is disabled, then nothing will be drawn to the window.", convar->getConVarByName("vr_draw_hmd_to_window"));
 		addCheckbox("Draw Both Eyes to Window", "Only applies if \"Draw HMD to Window\" is enabled, see above.", convar->getConVarByName("vr_draw_hmd_to_window_draw_both_eyes"));
-		addCheckbox("Draw Laser", convar->getConVarByName("osu_vr_draw_laser"));
+		addCheckbox("Draw Laser in Game", convar->getConVarByName("osu_vr_draw_laser_game"));
+		addCheckbox("Draw Laser in Menu", convar->getConVarByName("osu_vr_draw_laser_menu"));
 		addCheckbox("Draw Floor", convar->getConVarByName("osu_vr_draw_floor"));
 		addCheckbox("Draw Controller Models", convar->getConVarByName("vr_draw_controller_models"));
 		addCheckbox("Draw Lighthouse Models", convar->getConVarByName("vr_draw_lighthouse_models"));

--- a/src/App/Osu/OsuVR.cpp
+++ b/src/App/Osu/OsuVR.cpp
@@ -58,7 +58,8 @@ ConVar osu_vr_slider_controller_vibration_strength("osu_vr_slider_controller_vib
 
 ConVar osu_vr_draw_playfield("osu_vr_draw_playfield", true);
 ConVar osu_vr_draw_floor("osu_vr_draw_floor", true);
-ConVar osu_vr_draw_laser("osu_vr_draw_laser", true);
+ConVar osu_vr_draw_laser_game("osu_vr_draw_laser_game", true);
+ConVar osu_vr_draw_laser_menu("osu_vr_draw_laser_menu", true);
 
 ConVar osu_vr_ui_offset("osu_vr_ui_offset", 0.1f);
 
@@ -374,7 +375,9 @@ void OsuVR::drawVR(Graphics *g, Matrix4 &mvp, RenderTarget *screen)
 	}
 
 	// draw controller laser
-	if (m_bDrawLaser && openvr->hasInputFocus() && osu_vr_draw_laser.getBool())
+	bool drawInGame = m_osu->isInPlayMode() && osu_vr_draw_laser_game.getBool();
+	bool drawInMenu = m_osu->isNotInPlayModeOrPaused() && osu_vr_draw_laser_menu.getBool();
+	if (m_bDrawLaser && openvr->hasInputFocus() && (drawInGame || drawInMenu))
 	{
 		m_shaderGenericUntextured->enable();
 		{


### PR DESCRIPTION
Removed osu_vr_draw_laser and added osu_vr_draw_laser_game and osu_vr_draw_laser_menu instead, added slider for vr_head_rendermodel_brightness as it may dazzle in dark setup.