### PR TITLE
Fix drawHitCircleNumber for variable number width skins

### DIFF
--- a/src/App/Osu/OsuCircle.cpp
+++ b/src/App/Osu/OsuCircle.cpp
@@ -304,8 +304,6 @@ void OsuCircle::drawHitCircleNumber(Graphics *g, OsuSkin *skin, float numberScal
 	}
 	digits.push_back(number);
 
-	int digitOffsetMultiplier = digits.size()-1;
-
 	// set color
 	g->setColor(0xffffffff);
 	if (osu_circle_number_rainbow.getBool())
@@ -325,8 +323,15 @@ void OsuCircle::drawHitCircleNumber(Graphics *g, OsuSkin *skin, float numberScal
 	g->pushTransform();
 	g->scale(numberScale, numberScale);
 	g->translate(pos.x, pos.y);
-	g->translate(-DigitWidth::getWidth(skin, (digits.size() > 0 ? digits[digits.size()-1] : 0))*digitOffsetMultiplier*numberScale*0.5f + skin->getHitCircleOverlap()*digitOffsetMultiplier*overlapScale*0.5f, 0);
 
+	float digitWidthCombined = 0.0f;
+	for (int i = 0; i < digits.size(); i++)
+		digitWidthCombined += DigitWidth::getWidth(skin, digits[i]);
+	int digitOverlapCount = digits.size()-1; // inserting this line directly causes an overflow error with negative hitCircleOverlap number
+
+	g->translate(-(digitWidthCombined*numberScale - skin->getHitCircleOverlap()*digitOverlapCount*overlapScale)*0.5f + DigitWidth::getWidth(skin, (digits.size() > 0 ? digits[digits.size()-1] : 0))*numberScale*0.5f, 0);
+
+	// draw digits from high to low digit
 	for (int i=digits.size()-1; i>=0; i--)
 	{
 		switch (digits[i])
@@ -363,7 +368,8 @@ void OsuCircle::drawHitCircleNumber(Graphics *g, OsuSkin *skin, float numberScal
 			break;
 		}
 
-		g->translate(DigitWidth::getWidth(skin, digits[i])*numberScale - skin->getHitCircleOverlap()*overlapScale, 0);
+		if (i > 0)
+			g->translate((DigitWidth::getWidth(skin, digits[i])*numberScale + DigitWidth::getWidth(skin, digits[i-1])*numberScale)*0.5f - skin->getHitCircleOverlap()*overlapScale, 0);
 	}
 	g->popTransform();
 }


### PR DESCRIPTION
When a hitcircle number goes over a digit, the number placement breaks with variable number width skins.
This PR fixes that bug of drawHitCircleNumber() method.
Tested with both positive and negative HitCircleOverlap numbers of skin.ini.

Since most ranked maps circle number stays on a digit, I considered this bug not significant and did it by myself.

![Screenshot_12](https://user-images.githubusercontent.com/44800937/97085530-0105f480-1659-11eb-82d5-4e0afe27c0c8.png)